### PR TITLE
CATROID-725 Added context sensitive regular expression editor dialog

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,0 @@
-Catroid

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -8,9 +8,6 @@
     <option name="LINE_SEPARATOR" value="&#10;" />
     <option name="WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN" value="true" />
     <option name="FORMATTER_TAGS_ENABLED" value="true" />
-    <AndroidXmlCodeStyleSettings>
-      <option name="USE_CUSTOM_SETTINGS" value="true" />
-    </AndroidXmlCodeStyleSettings>
     <JavaCodeStyleSettings>
       <option name="BLANK_LINES_AROUND_INITIALIZER" value="0" />
       <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="9999" />
@@ -73,9 +70,6 @@
       <option name="XML_KEEP_WHITESPACES" value="true" />
       <option name="XML_ATTRIBUTE_WRAP" value="0" />
       <option name="XML_TEXT_WRAP" value="0" />
-      <option name="XML_KEEP_LINE_BREAKS" value="false" />
-      <option name="XML_ALIGN_ATTRIBUTES" value="false" />
-      <option name="XML_SPACE_INSIDE_EMPTY_TAG" value="true" />
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
     </XML>
     <codeStyleSettings language="JAVA">
@@ -100,7 +94,6 @@
       </indentOptions>
     </codeStyleSettings>
     <codeStyleSettings language="XML">
-      <option name="FORCE_REARRANGE_MODE" value="1" />
       <indentOptions>
         <option name="CONTINUATION_INDENT_SIZE" value="4" />
       </indentOptions>

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorRegexDetectionTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/formulaeditor/FormulaEditorRegexDetectionTest.java
@@ -1,0 +1,150 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2020 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.formulaeditor;
+
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.bricks.SetVariableBrick;
+import org.catrobat.catroid.ui.SpriteActivity;
+import org.catrobat.catroid.uiespresso.content.brick.utils.BrickTestUtils;
+import org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper;
+import org.catrobat.catroid.uiespresso.util.UiTestUtils;
+import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import androidx.test.espresso.NoMatchingViewException;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper.onBrickAtPosition;
+import static org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper.onFormulaEditor;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+
+@RunWith(AndroidJUnit4.class)
+public class FormulaEditorRegexDetectionTest {
+
+	@Rule
+	public FragmentActivityTestRule<SpriteActivity> baseActivityTestRule = new
+			FragmentActivityTestRule<>(SpriteActivity.class, SpriteActivity.EXTRA_FRAGMENT_POSITION, SpriteActivity.FRAGMENT_SCRIPTS);
+
+	@Before
+	public void setup() {
+		Script script = BrickTestUtils.createProjectAndGetStartScript(
+				"FormulaEditorRegExDetectionTest");
+		script.addBrick(new SetVariableBrick(0));
+		baseActivityTestRule.launchActivity();
+	}
+
+	@Test
+	public void testNonRegexFunctionChangeText() {
+
+		String editorFunction = getFunctionEntryName(R.string.formula_editor_function_join,
+				R.string.formula_editor_function_join_parameter);
+		prepareUntilButton(editorFunction);
+
+		onView(withText(R.string.formula_editor_dialog_change_text)).check(matches(isDisplayed()));
+
+
+	}
+
+	@Test (expected = NoMatchingViewException.class)
+	public void testNonRegexFunctionNoAssistantButton() {
+		String editorFunction = getFunctionEntryName(R.string.formula_editor_function_join,
+				R.string.formula_editor_function_join_parameter);
+		prepareUntilButton(editorFunction);
+		onView(withText(R.string.assistant)).check(matches(isDisplayed()));
+
+	}
+
+	@Test
+	public void testRegexFunctionFirstParamChangeRegexText() {
+
+		String editorFunction = getFunctionEntryName(R.string.formula_editor_function_regex,
+				R.string.formula_editor_function_regex_parameter);
+		prepareUntilButton(editorFunction);
+
+		onView(withText(R.string.formula_editor_dialog_change_regular_expression)).check(matches(isDisplayed()));
+	}
+
+	@Test
+	public void testRegexFunctionFirstParamAssistantButton() {
+
+		String editorFunction = getFunctionEntryName(R.string.formula_editor_function_regex,
+				R.string.formula_editor_function_regex_parameter);
+		prepareUntilButton(editorFunction);
+
+		onView(withText(R.string.assistant)).check(matches(isDisplayed()));
+	}
+
+	//@Test
+	public void testRegexFunctionSecondParamChangeText() {
+
+		String editorFunction = getFunctionEntryName(R.string.formula_editor_function_regex,
+				R.string.formula_editor_function_regex_parameter);
+
+		prepareUntilButton(editorFunction);
+		//select 2nd param.
+		onView(withText(R.string.formula_editor_dialog_change_text)).check(matches(isDisplayed()));
+
+	}
+
+	//@Test (expected = NoMatchingViewException.class)
+	public void testRegexFunctionSecondParamNoAssistantButton() {
+
+		String editorFunction = getFunctionEntryName(R.string.formula_editor_function_regex,
+				R.string.formula_editor_function_regex_parameter);
+
+		prepareUntilButton(editorFunction);
+		//select 2nd param.
+		onView(withText(R.string.assistant)).check(matches(isDisplayed()));
+
+	}
+
+	@After
+	public void teardown() {
+
+	}
+	private void prepareUntilButton(String nameOfFunction) {
+		onBrickAtPosition(1).onChildView(withId(R.id.brick_set_variable_edit_text)).perform(click());
+		onFormulaEditor().performOpenCategory(FormulaEditorWrapper.Category.FUNCTIONS).performSelect(nameOfFunction);
+		onFormulaEditor().performClickOn(FormulaEditorWrapper.Control.TEXT);
+
+	}
+
+	private String getFunctionEntryName(int functionName, int paramName) {
+		String functionString = UiTestUtils.getResourcesString(functionName);
+		String paramString = UiTestUtils.getResourcesString(paramName);
+		return functionString + paramString;
+	}
+
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/CategoryListFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/CategoryListFragmentTest.java
@@ -1,0 +1,116 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2020 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.uiespresso.ui.fragment;
+
+import android.view.View;
+import android.widget.TextView;
+
+import org.catrobat.catroid.R;
+import org.catrobat.catroid.content.Script;
+import org.catrobat.catroid.content.bricks.ChangeSizeByNBrick;
+import org.catrobat.catroid.testsuites.annotations.Cat;
+import org.catrobat.catroid.testsuites.annotations.Level;
+import org.catrobat.catroid.ui.SpriteActivity;
+import org.catrobat.catroid.uiespresso.content.brick.utils.BrickTestUtils;
+import org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper;
+import org.catrobat.catroid.uiespresso.util.UiTestUtils;
+import org.catrobat.catroid.uiespresso.util.rules.FragmentActivityTestRule;
+import org.hamcrest.Matcher;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import androidx.test.espresso.UiController;
+import androidx.test.espresso.ViewAction;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.catrobat.catroid.uiespresso.content.brick.utils.BrickDataInteractionWrapper.onBrickAtPosition;
+import static org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper.FORMULA_EDITOR_TEXT_FIELD_MATCHER;
+import static org.catrobat.catroid.uiespresso.formulaeditor.utils.FormulaEditorWrapper.onFormulaEditor;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+
+@Category({Cat.AppUi.class, Level.Smoke.class})
+@RunWith(AndroidJUnit4.class)
+public class CategoryListFragmentTest {
+
+	@Rule
+	public FragmentActivityTestRule<SpriteActivity> baseActivityTestRule = new
+			FragmentActivityTestRule<>(SpriteActivity.class, SpriteActivity.EXTRA_FRAGMENT_POSITION, SpriteActivity.FRAGMENT_SCRIPTS);
+
+	private static Integer whenBrickPosition = 0;
+	private static Integer changeSizeBrickPosition = 1;
+
+	@Test
+	public void testRegexButtonImplementation() {
+		Script script = BrickTestUtils.createProjectAndGetStartScript("RegexAssistantButtonTest");
+		script.addBrick(new ChangeSizeByNBrick(0));
+		baseActivityTestRule.launchActivity();
+
+		onBrickAtPosition(whenBrickPosition).checkShowsText(R.string.brick_when_started);
+		onBrickAtPosition(changeSizeBrickPosition).checkShowsText(R.string.brick_change_size_by);
+		onBrickAtPosition(changeSizeBrickPosition).onChildView(withId(R.id.brick_change_size_by_edit_text))
+				.perform(click());
+
+		String regular_expression_assistant =
+				UiTestUtils.getResourcesString(R.string.formula_editor_function_regex_assistant);
+
+		String formulaEditorTextFieldBeforeButtonClick = getFormulaEditorText(FORMULA_EDITOR_TEXT_FIELD_MATCHER);
+
+		//Tests if button exists
+		onFormulaEditor()
+				.performOpenCategory(FormulaEditorWrapper.Category.FUNCTIONS)
+				.performOnItemWithText(regular_expression_assistant, click());
+
+		//Test if button doesn't change formula editor textfield
+		Assert.assertEquals(formulaEditorTextFieldBeforeButtonClick, getFormulaEditorText(FORMULA_EDITOR_TEXT_FIELD_MATCHER));
+	}
+
+	String getFormulaEditorText(final Matcher<View> matcher) {
+		final String[] stringHolder = { null };
+		onView(matcher).perform(new ViewAction() {
+			@Override
+			public Matcher<View> getConstraints() {
+				return isAssignableFrom(TextView.class);
+			}
+
+			@Override
+			public String getDescription() {
+				return "getting text from a TextView";
+			}
+
+			@Override
+			public void perform(UiController uiController, View view) {
+				TextView tv = (TextView)view; //Save, because of check in getConstraints()
+				stringHolder[0] = tv.getText().toString();
+			}
+		});
+		return stringHolder[0];
+	}
+}

--- a/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/CategoryListFragmentTest.java
+++ b/catroid/src/androidTest/java/org/catrobat/catroid/uiespresso/ui/fragment/CategoryListFragmentTest.java
@@ -78,7 +78,7 @@ public class CategoryListFragmentTest {
 		onBrickAtPosition(changeSizeBrickPosition).onChildView(withId(R.id.brick_change_size_by_edit_text))
 				.perform(click());
 
-		String regular_expression_assistant =
+		String regularExpressionAssistant =
 				UiTestUtils.getResourcesString(R.string.formula_editor_function_regex_assistant);
 
 		String formulaEditorTextFieldBeforeButtonClick = getFormulaEditorText(FORMULA_EDITOR_TEXT_FIELD_MATCHER);
@@ -86,14 +86,14 @@ public class CategoryListFragmentTest {
 		//Tests if button exists
 		onFormulaEditor()
 				.performOpenCategory(FormulaEditorWrapper.Category.FUNCTIONS)
-				.performOnItemWithText(regular_expression_assistant, click());
+				.performOnItemWithText(regularExpressionAssistant, click());
 
 		//Test if button doesn't change formula editor textfield
 		Assert.assertEquals(formulaEditorTextFieldBeforeButtonClick, getFormulaEditorText(FORMULA_EDITOR_TEXT_FIELD_MATCHER));
 	}
 
 	String getFormulaEditorText(final Matcher<View> matcher) {
-		final String[] stringHolder = { null };
+		final String[] stringHolder = {null};
 		onView(matcher).perform(new ViewAction() {
 			@Override
 			public Matcher<View> getConstraints() {
@@ -107,7 +107,7 @@ public class CategoryListFragmentTest {
 
 			@Override
 			public void perform(UiController uiController, View view) {
-				TextView tv = (TextView)view; //Save, because of check in getConstraints()
+				TextView tv = (TextView) view; //Save, because of check in getConstraints()
 				stringHolder[0] = tv.getText().toString();
 			}
 		});

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaEditorEditText.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/FormulaEditorEditText.java
@@ -49,7 +49,7 @@ public class FormulaEditorEditText extends EditText implements OnTouchListener {
 	private static final BackgroundColorSpan COLOR_HIGHLIGHT = new BackgroundColorSpan(0xFF33B5E5);
 	private FormulaEditorHistory history = null;
 	FormulaEditorFragment formulaEditorFragment = null;
-	private int absoluteCursorPosition = 0;
+	public int absoluteCursorPosition = 0;
 	private InternFormula internFormula;
 	private Context context;
 	private Paint paint = new Paint();
@@ -271,6 +271,10 @@ public class FormulaEditorEditText extends EditText implements OnTouchListener {
 
 	public String getSelectedTextFromInternFormula() {
 		return internFormula.getSelectedText();
+	}
+
+	public boolean isSelectedTokenFirstParamOfRegularExpression() {
+		return internFormula.isSelectedTokenFirstParamOfRegularExpression();
 	}
 
 	public void overrideSelectedText(String string) {

--- a/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormula.java
+++ b/catroid/src/main/java/org/catrobat/catroid/formulaeditor/InternFormula.java
@@ -966,6 +966,56 @@ public class InternFormula {
 		return null;
 	}
 
+	public boolean isSelectedTokenFirstParamOfRegularExpression() {
+
+		boolean isFirstParamInRegularExpression = false;
+
+		if (internFormulaTokenSelection != null) {
+			int indexOfSelectedTokenInTokenSelection = internFormulaTokenSelection.getStartIndex();
+
+			if (indexOfSelectedTokenInTokenSelection >= 2) {
+
+				isFirstParamInRegularExpression =
+						isSelectedTokenTypeString(indexOfSelectedTokenInTokenSelection)
+								&& isTokenBeforeSelectedTypeBracketOpen(indexOfSelectedTokenInTokenSelection)
+								&& isTwoTokensBeforeSelectedAFunctionAndNamedRegex(indexOfSelectedTokenInTokenSelection);
+			}
+		}
+		return isFirstParamInRegularExpression;
+	}
+
+	private boolean isSelectedTokenTypeString(int index) {
+		boolean isString = true;
+		InternTokenType typeString = InternTokenType.STRING;
+		if (!(internTokenFormulaList.get(index).getInternTokenType()
+				== typeString)) {
+			isString = false;
+		}
+		return isString;
+	}
+
+	private boolean isTokenBeforeSelectedTypeBracketOpen(int index) {
+		boolean isBracket = true;
+		InternTokenType typeBracketOpen = InternTokenType.FUNCTION_PARAMETERS_BRACKET_OPEN;
+		if (!(internTokenFormulaList.get(index - 1).getInternTokenType()
+				== typeBracketOpen)) {
+			isBracket = false;
+		}
+		return isBracket;
+	}
+
+	private boolean isTwoTokensBeforeSelectedAFunctionAndNamedRegex(int index) {
+		boolean isRegex = true;
+		InternTokenType typeFunctionName = InternTokenType.FUNCTION_NAME;
+		String stringOfRegularExpression = "REGEX";
+		InternToken functionToken = internTokenFormulaList.get(index - 2);
+		if (!(functionToken.getInternTokenType() == typeFunctionName
+				&& functionToken.getTokenStringValue().equals(stringOfRegularExpression))) {
+			isRegex = false;
+		}
+		return isRegex;
+	}
+
 	public String getSelectedText() {
 		InternToken token = getSelectedToken();
 		if (token == null) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/fragment/FormulaEditorFragment.java
@@ -23,12 +23,14 @@
 package org.catrobat.catroid.ui.fragment;
 
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.Rect;
 import android.location.LocationManager;
 import android.os.Bundle;
 import android.os.Handler;
 import android.provider.Settings;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -327,7 +329,11 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 							endFormulaEditor();
 							return true;
 						case R.id.formula_editor_keyboard_string:
-							showNewStringDialog();
+							if (isSelectedTextFirstParamOfRegularExpression()) {
+								showNewRegexAssistantDialog();
+							} else {
+								showNewStringDialog();
+							}
 							return true;
 						case R.id.formula_editor_keyboard_delete:
 							formulaEditorEditText.handleKeyEvent(view.getId(), "");
@@ -366,6 +372,34 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 		((AppCompatActivity) getActivity()).getSupportActionBar().setTitle(actionBarTitleBuffer);
 	}
 
+	private boolean isSelectedTextFirstParamOfRegularExpression() {
+		return getFormulaEditorEditText().isSelectedTokenFirstParamOfRegularExpression();
+	}
+
+	private void showNewRegexAssistantDialog() {
+		String selectedFormulaText = getSelectedFormulaText();
+
+		TextInputDialog.Builder builder = new TextInputDialog.Builder(getContext());
+
+		builder.setHint(getString(R.string.string_label))
+				.setText(selectedFormulaText)
+				.setPositiveButton(getString(R.string.ok), (TextInputDialog.OnClickListener) (dialog, textInput) -> addString(textInput));
+
+		int titleId = R.string.formula_editor_dialog_change_regular_expression;
+
+		builder.setNeutralButton(R.string.assistant,
+				(DialogInterface.OnClickListener) (dialog, textInput) -> regexTesting());
+
+		builder.setTitle(titleId)
+				.setNegativeButton(R.string.cancel, null)
+				.show();
+
+	}
+
+	private void regexTesting() {
+		Log.i("REGEX BUTTON", "Button Press detected");
+	}
+
 	private void showNewStringDialog() {
 		String selectedFormulaText = getSelectedFormulaText();
 
@@ -381,6 +415,7 @@ public class FormulaEditorFragment extends Fragment implements ViewTreeObserver.
 		builder.setTitle(titleId)
 				.setNegativeButton(R.string.cancel, null)
 				.show();
+
 	}
 
 	public void addString(String string) {

--- a/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/CategoryListFragment.java
+++ b/catroid/src/main/java/org/catrobat/catroid/ui/recyclerview/fragment/CategoryListFragment.java
@@ -116,10 +116,10 @@ public class CategoryListFragment extends Fragment implements CategoryListRVAdap
 			R.string.formula_editor_function_max_parameter, R.string.formula_editor_function_min_parameter);
 	private static final List<Integer> STRING_FUNCTIONS = Arrays.asList(R.string.formula_editor_function_length,
 			R.string.formula_editor_function_letter, R.string.formula_editor_function_join,
-			R.string.formula_editor_function_regex);
+			R.string.formula_editor_function_regex, R.string.formula_editor_function_regex_assistant);
 	private static final List<Integer> STRING_PARAMS = Arrays.asList(R.string.formula_editor_function_length_parameter,
 			R.string.formula_editor_function_letter_parameter, R.string.formula_editor_function_join_parameter,
-			R.string.formula_editor_function_regex_parameter);
+			R.string.formula_editor_function_regex_parameter, R.string.formula_editor_function_no_parameter);
 	private static final List<Integer> LIST_FUNCTIONS = Arrays.asList(R.string.formula_editor_function_number_of_items,
 			R.string.formula_editor_function_list_item, R.string.formula_editor_function_contains,
 			R.string.formula_editor_function_index_of_item);
@@ -273,6 +273,8 @@ public class CategoryListFragment extends Fragment implements CategoryListRVAdap
 			case CategoryListRVAdapter.DEFAULT:
 				if (LIST_FUNCTIONS.contains(item.nameResId)) {
 					onUserListFunctionSelected(item);
+				} else if (R.string.formula_editor_function_regex_assistant == item.nameResId) {
+					getActivity().onBackPressed();
 				} else {
 					addResourceToActiveFormulaInFormulaEditor(item);
 					getActivity().onBackPressed();

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -1757,6 +1757,8 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_function_join_parameter">(\'hello\',\' world\')</string>
     <string name="formula_editor_function_regex">regular expression</string>
     <string name="formula_editor_function_regex_parameter">(\' an? ([^ .]+)\',\'I am a panda.\')</string>
+    <string name="formula_editor_function_regex_assistant">\t\t\t\t\t Regular expression
+        assistant</string>
     <string name="formula_editor_function_arduino_read_pin_value_digital">arduino digital pin</string>
     <string name="formula_editor_function_arduino_read_pin_value_analog">arduino analog pin</string>
     <string name="formula_editor_function_raspi_read_pin_value_digital">raspberry pi pin</string>

--- a/catroid/src/main/res/values/strings.xml
+++ b/catroid/src/main/res/values/strings.xml
@@ -43,6 +43,8 @@
     <string name="done">Done</string>
     <string name="close">Close</string>
 
+    <string name= "assistant">Assistant</string>
+
     <string name="yes">Yes</string>
     <string name="no">No</string>
 
@@ -1914,6 +1916,8 @@ needs read and write access to it. You can always change permissions through you
     <string name="formula_editor_discard_changes_dialog_title">Save changes?</string>
     <string name="formula_editor_new_string_name">New text</string>
     <string name="formula_editor_dialog_change_text">Change text</string>
+    <string name="formula_editor_dialog_change_regular_expression">Change regular
+        expression</string>
     <string name="formula_editor_fragment_data_current_items">current items</string>
     <string name="formula_editor_data_dialog_is_list">Make it a list</string>
     <string name="formula_editor_sensor_face_detected">face is visible</string>

--- a/catroid/src/test/java/org/catrobat/catroid/test/formulaeditor/InternFormulaRegexDetectionTest.java
+++ b/catroid/src/test/java/org/catrobat/catroid/test/formulaeditor/InternFormulaRegexDetectionTest.java
@@ -1,0 +1,139 @@
+/*
+ * Catroid: An on-device visual programming system for Android devices
+ * Copyright (C) 2010-2020 The Catrobat Team
+ * (<http://developer.catrobat.org/credits>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * An additional term exception under section 7 of the GNU Affero
+ * General Public License, version 3, is available at
+ * http://developer.catrobat.org/license_additional_term
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.catrobat.catroid.test.formulaeditor;
+
+import android.content.Context;
+
+import org.catrobat.catroid.formulaeditor.Functions;
+import org.catrobat.catroid.formulaeditor.InternFormula;
+import org.catrobat.catroid.formulaeditor.InternToken;
+import org.catrobat.catroid.formulaeditor.InternTokenType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.assertFalse;
+
+@RunWith(JUnit4.class)
+public class InternFormulaRegexDetectionTest {
+
+	private InternFormula internFormula;
+
+	@Test
+	public void testEmptyFormula() {
+		ArrayList<InternToken> internTokens = new ArrayList<>();
+		internFormula = new InternFormula(internTokens);
+		internFormula.generateExternFormulaStringAndInternExternMapping(Mockito.mock(Context.class));
+
+		int doubleClickIndex = 0;
+		internFormula.setCursorAndSelection(doubleClickIndex, true);
+
+		assertFalse("EmptyList should not be inside a regular expression",
+				internFormula.isSelectedTokenFirstParamOfRegularExpression());
+	}
+
+	@Test
+	public void testFormulaWithoutRegex() {
+		ArrayList<InternToken> internTokens = new ArrayList<>();
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_NAME, Functions.JOIN.name()));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETERS_BRACKET_OPEN));
+		internTokens.add(new InternToken(InternTokenType.STRING, "Hello"));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETER_DELIMITER));
+		internTokens.add(new InternToken(InternTokenType.STRING, "World"));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETERS_BRACKET_CLOSE));
+
+		internFormula = new InternFormula(internTokens);
+		internFormula.generateExternFormulaStringAndInternExternMapping(Mockito.mock(Context.class));
+
+		int doubleClickIndex = internFormula.getExternFormulaString().indexOf("Hello") + 1;
+		internFormula.setCursorAndSelection(doubleClickIndex, true);
+
+		assertFalse("Formula without a regular expression cannot have a first regex param",
+				internFormula.isSelectedTokenFirstParamOfRegularExpression());
+	}
+
+	@Test
+	public void testFormulaWithNoBracketInFrontOfSelection() {
+		ArrayList<InternToken> internTokens = new ArrayList<>();
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_NAME, Functions.REGEX.name()));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETER_DELIMITER));
+		internTokens.add(new InternToken(InternTokenType.STRING, "Hello"));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETER_DELIMITER));
+		internTokens.add(new InternToken(InternTokenType.STRING, "World"));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETERS_BRACKET_CLOSE));
+
+		internFormula = new InternFormula(internTokens);
+		internFormula.generateExternFormulaStringAndInternExternMapping(Mockito.mock(Context.class));
+
+		int doubleClickIndex = internFormula.getExternFormulaString().indexOf("Hello") + 1;
+		internFormula.setCursorAndSelection(doubleClickIndex, true);
+
+		assertFalse("If there is not bracket in front then this cant be the first param",
+				internFormula.isSelectedTokenFirstParamOfRegularExpression());
+	}
+
+	@Test
+	public void testRegexFormulaWithSelectedFirstParamNotString() {
+		ArrayList<InternToken> internTokens = new ArrayList<>();
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_NAME, Functions.REGEX.name()));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETERS_BRACKET_OPEN));
+		internTokens.add(new InternToken(InternTokenType.USER_VARIABLE, "Hello"));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETER_DELIMITER));
+		internTokens.add(new InternToken(InternTokenType.STRING, "World"));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETERS_BRACKET_CLOSE));
+
+		internFormula = new InternFormula(internTokens);
+		internFormula.generateExternFormulaStringAndInternExternMapping(Mockito.mock(Context.class));
+
+		int doubleClickIndex = internFormula.getExternFormulaString().indexOf("Hello") + 1;
+		internFormula.setCursorAndSelection(doubleClickIndex, true);
+
+		assertFalse("If there is not bracket in front then this cant be the first param",
+				internFormula.isSelectedTokenFirstParamOfRegularExpression());
+	}
+
+	@Test
+	public void testCorrectRegexWithFirstParamSelected() {
+		ArrayList<InternToken> internTokens = new ArrayList<>();
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_NAME, Functions.REGEX.name()));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETERS_BRACKET_OPEN));
+		internTokens.add(new InternToken(InternTokenType.STRING, "Hello"));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETER_DELIMITER));
+		internTokens.add(new InternToken(InternTokenType.STRING, "World"));
+		internTokens.add(new InternToken(InternTokenType.FUNCTION_PARAMETERS_BRACKET_CLOSE));
+
+		internFormula = new InternFormula(internTokens);
+		internFormula.generateExternFormulaStringAndInternExternMapping(Mockito.mock(Context.class));
+
+		int doubleClickIndex = internFormula.getExternFormulaString().indexOf("Hello") + 1;
+		internFormula.setCursorAndSelection(doubleClickIndex, true);
+
+		assertTrue("First param in regex should be found",
+				internFormula.isSelectedTokenFirstParamOfRegularExpression());
+	}
+}


### PR DESCRIPTION
CATROID-725 Added context sensitive regular expression editor dialog. If first param of a regular expression is selected, an extended dialog option is shown. The dialog shown has the title "Change regular expression" and has a "Assistant" button without implemented functionality.
https://jira.catrob.at/browse/CATROID-725

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroid/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s gitflow workflow
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *catroid-stage* or *catroid-ide* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
